### PR TITLE
add empty range when getSelection is 0

### DIFF
--- a/src/useEditable.ts
+++ b/src/useEditable.ts
@@ -70,6 +70,9 @@ const getPosition = (element: HTMLElement): Position => {
   // Firefox Quirk: Since plaintext-only is unsupported the position
   // of the text here is retrieved via a range, rather than traversal
   // as seen in makeRange()
+  if (window.getSelection()!.rangeCount === 0) {
+    setCurrentRange(document.createRange());
+  }
   const range = getCurrentRange();
   const extent = !range.collapsed ? range.toString().length : 0;
   const untilRange = document.createRange();


### PR DESCRIPTION
## What?
When `window.getSelection` has no ranges, `getCurrentRange()` fails. 
This changes adds an empty range so `getCurrentRange()` does not fail.
## Why?
This is to fix a bug which appears on chrome. It does not appear on firefox.
Steps to reproduce bug:
1. Open demo on chrome: https://codesandbox.io/s/use-editable-0l9kc
2. Click on the text in the Edit component in browser.
You get the error "IndexSizeError Failed to execute 'getRangeAt' on 'Selection': 0 is not a valid index."
![Screenshot from 2021-04-14 15-00-10](https://user-images.githubusercontent.com/5191207/114714172-23d4b400-9d32-11eb-991b-18e0d0f7f6cf.png)

(You can close the error, click outside the Edit component but within the browser and click again on the Edit component. The error appears again)
## How?
The bug is caused by `getSelection` having no ranges. We add an empty range when `getSelection` has no ranges.
## Testing?
This PR solves the bug on local machine, or rather the error does not appear.

Open to review, comments and changes.