### PR TITLE
Specify useLayoutEffect dependency array

### DIFF
--- a/src/useEditable.ts
+++ b/src/useEditable.ts
@@ -258,7 +258,7 @@ export const useEditable = (
   useLayoutEffect(() => {
     state.onChange = onChange;
 
-    if (!elementRef.current || opts!.disabled) return;
+    if (!elementRef.current || opts?.disabled) return;
 
     state.disconnected = false;
     state.observer.observe(elementRef.current, observerSettings);
@@ -272,7 +272,7 @@ export const useEditable = (
     return () => {
       state.observer.disconnect();
     };
-  });
+  }, [elementRef, onChange, opts.disabled, state, state.disconnected, state.observer, state.position]);
 
   useLayoutEffect(() => {
     if (!elementRef.current || opts!.disabled) {


### PR DESCRIPTION
Executing this effect upon every react re-render can cause the focus to be stolen when a user is interacting with other components. Specifying the appropriate dependency array should ensure that the effect is only executed when necessary.

This fixes #16 