### PR TITLE
refactor MutationObserver state initialization to resolve potential identifier conflicts

### DIFF
--- a/src/useEditable.ts
+++ b/src/useEditable.ts
@@ -178,7 +178,7 @@ export const useEditable = (
   if (!opts) opts = {};
 
   const unblock = useState([])[1];
-  const state: State = useState(() => {
+  const createInitialState = (): State => {
     const state: State = {
       observer: null as any,
       disconnected: false,
@@ -190,13 +190,14 @@ export const useEditable = (
     };
 
     if (typeof MutationObserver !== 'undefined') {
-      state.observer = new MutationObserver(batch => {
-        state.queue.push(...batch);
+      state.observer = new MutationObserver(mutations => {
+        state.queue.push(...mutations);
       });
     }
 
     return state;
-  })[0];
+  };
+  const state: State = useState(() => createInitialState())[0];
 
   const edit = useMemo<Edit>(
     () => ({


### PR DESCRIPTION
### Description

Fix: initialize MutationObserver state in useEditable to resolve potential identifier conflicts

Fixes #34 

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
